### PR TITLE
Enable build using standard WebRTC

### DIFF
--- a/tgcalls/CodecSelectHelper.cpp
+++ b/tgcalls/CodecSelectHelper.cpp
@@ -26,7 +26,9 @@ bool CompareFormats(const VideoFormat &a, const VideoFormat &b) {
 int FormatPriority(const VideoFormat &format, const std::vector<std::string> &preferredCodecs) {
 	static const auto kCodecs = {
 		std::string(cricket::kAv1CodecName),
+#ifndef WEBRTC_DISABLE_H265
 		std::string(cricket::kH265CodecName),
+#endif
 		std::string(cricket::kH264CodecName),
 		std::string(cricket::kVp8CodecName),
         std::string(cricket::kVp9CodecName),

--- a/tgcalls/LogSinkImpl.cpp
+++ b/tgcalls/LogSinkImpl.cpp
@@ -29,7 +29,6 @@ void LogSinkImpl::OnLogMessage(const std::string &message) {
 	time_t rawTime;
 	time(&rawTime);
 	struct tm timeinfo;
-	timeval curTime = { 0 };
 
 #ifdef WEBRTC_WIN
 	localtime_s(&timeinfo, &rawTime);
@@ -45,14 +44,13 @@ void LogSinkImpl::OnLogMessage(const std::string &message) {
 	const auto deltaEpochInMicrosecs = 11644473600000000Ui64;
 	full -= deltaEpochInMicrosecs;
 	full /= 10;
-	curTime.tv_sec = (long)(full / 1000000UL);
-	curTime.tv_usec = (long)(full % 1000000UL);
+	int32_t milliseconds = (long)(full % 1000000UL) / 1000;
 #else
+	timeval curTime = { 0 };
 	localtime_r(&rawTime, &timeinfo);
 	gettimeofday(&curTime, nullptr);
-#endif
-
 	int32_t milliseconds = curTime.tv_usec / 1000;
+#endif
 
 	auto &stream = _file.is_open() ? (std::ostream&)_file : _data;
 	stream

--- a/tgcalls/MediaManager.cpp
+++ b/tgcalls/MediaManager.cpp
@@ -604,7 +604,9 @@ void MediaManager::checkIsReceivingVideoChanged(bool wasReceiving) {
         const auto codecs = {
             cricket::kFlexfecCodecName,
             cricket::kH264CodecName,
+#ifndef WEBRTC_DISABLE_H265
             cricket::kH265CodecName,
+#endif
             cricket::kVp8CodecName,
             cricket::kVp9CodecName,
             cricket::kAv1CodecName,

--- a/tgcalls/reference/InstanceImplReference.cpp
+++ b/tgcalls/reference/InstanceImplReference.cpp
@@ -874,11 +874,15 @@ private:
 
                 std::vector<webrtc::RtpCodecCapability> codecs;
                 for (auto &codec : capabilities.codecs) {
+#ifndef WEBRTC_DISABLE_H265
                     if (codec.name == cricket::kH265CodecName) {
                         codecs.insert(codecs.begin(), codec);
                     } else {
                         codecs.push_back(codec);
                     }
+#else
+                    codecs.push_back(codec);
+#endif
                 }
                 it->SetCodecPreferences(codecs);
 


### PR DESCRIPTION
I defined `WEBRTC_DISABLE_H265` so that the code can be built using standard WebRTC source code, as `cricket::kH265CodecName` comes from a fork.