### PR TITLE
Fix: incorrectly named parameters

### DIFF
--- a/tgcalls/desktop_capturer/DesktopCaptureSourceHelper.cpp
+++ b/tgcalls/desktop_capturer/DesktopCaptureSourceHelper.cpp
@@ -377,7 +377,7 @@ struct DesktopCaptureSourceHelper::Renderer {
 };
 
 DesktopCaptureSource DesktopCaptureSourceForKey(
-	    const std::string &uniqueKey) {
+	    const std::string &deviceIdKey) {
     if (!ShouldBeDesktopCapture(uniqueKey)) {
 		return DesktopCaptureSource::Invalid();
     }
@@ -401,7 +401,7 @@ DesktopCaptureSource DesktopCaptureSourceForKey(
     return DesktopCaptureSource::Invalid();
 }
 
-bool ShouldBeDesktopCapture(const std::string &uniqueKey) {
+bool ShouldBeDesktopCapture(const std::string &deviceIdKey) {
     return (uniqueKey.find("desktop_capturer_") == 0);
 }
 

--- a/tgcalls/desktop_capturer/DesktopCaptureSourceHelper.h
+++ b/tgcalls/desktop_capturer/DesktopCaptureSourceHelper.h
@@ -25,8 +25,8 @@ class VideoSinkInterface;
 namespace tgcalls {
 
 DesktopCaptureSource DesktopCaptureSourceForKey(
-	const std::string &uniqueKey);
-bool ShouldBeDesktopCapture(const std::string &uniqueKey);
+	const std::string &deviceIdKey);
+bool ShouldBeDesktopCapture(const std::string &deviceIdKey);
 
 class DesktopCaptureSourceHelper {
 public:


### PR DESCRIPTION
Change two function parameter name to deviceIdkey.

```cpp
DesktopCaptureSource DesktopCaptureSourceForKey(
	const std::string &uniqueKey);
bool ShouldBeDesktopCapture(const std::string &uniqueKey);
```

These function parameters has named "uniqueKey".

But in context of VideoCapturerInterfaceImpl, we get
```c++
VideoCapturerInterfaceImpl::VideoCapturerInterfaceImpl(
	rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> source,
	std::string deviceId,
	std::function<void(VideoState)> stateUpdated,
	std::shared_ptr<PlatformContext> platformContext,
	std::pair<int, int> &outResolution)
: _source(source)
, _sink(GetSink(source))
, _stateUpdated(stateUpdated) {

	if (const auto source = DesktopCaptureSourceForKey(deviceId)) {
		const auto data = DesktopCaptureSourceData{
			/*.aspectSize = */{ 1280, 720 },
			/*.fps = */24.,
			/*.captureMouse = */(deviceId != "desktop_capturer_pipewire"),
		};
		_desktopCapturer = std::make_unique<DesktopCaptureSourceHelper>(
			source,
			data);
		_desktopCapturer->setOutput(_sink);
		_desktopCapturer->start();
		outResolution = { 1280, 960 };
	} else if (!ShouldBeDesktopCapture(deviceId))
	{
		_cameraCapturer = std::make_unique<VideoCameraCapturer>(_sink);
		_cameraCapturer->setDeviceId(deviceId);
		_cameraCapturer->setState(VideoState::Active);
		outResolution = _cameraCapturer->resolution();
	}
}
```
We pass "device id" to DesktopCaptureSourceForKey(). So this naming is very confusing.
