### PR TITLE
Fix build against FFmpeg v5.0

### DIFF
--- a/tgcalls/group/AudioStreamingPartInternal.cpp
+++ b/tgcalls/group/AudioStreamingPartInternal.cpp
@@ -104,6 +104,9 @@ _avIoContext(std::move(fileData)) {
 
     _frame = av_frame_alloc();
 
+#if LIBAVFORMAT_VERSION_MAJOR >= 59
+    const
+#endif
     AVInputFormat *inputFormat = av_find_input_format(container.c_str());
     if (!inputFormat) {
         _didReadToEnd = true;
@@ -144,7 +147,7 @@ _avIoContext(std::move(fileData)) {
         
         _streamId = i;
 
-        _durationInMilliseconds = (int)((inStream->duration + inStream->first_dts) * 1000 / 48000);
+        _durationInMilliseconds = (int)(inStream->duration * av_q2d(inStream->time_base) * 1000);
 
         if (inStream->metadata) {
             AVDictionaryEntry *entry = av_dict_get(inStream->metadata, "TG_META", nullptr, 0);

--- a/tgcalls/group/AudioStreamingPartPersistentDecoder.cpp
+++ b/tgcalls/group/AudioStreamingPartPersistentDecoder.cpp
@@ -32,7 +32,7 @@ public:
     AudioStreamingPartPersistentDecoderState(AVCodecParameters const *codecParameters, AVRational timeBase) :
     _codecParameters(codecParameters),
     _timeBase(timeBase) {
-        AVCodec *codec = avcodec_find_decoder(codecParameters->codec_id);
+        const AVCodec *codec = avcodec_find_decoder(codecParameters->codec_id);
         if (codec) {
             _codecContext = avcodec_alloc_context3(codec);
             int ret = avcodec_parameters_to_context(_codecContext, codecParameters);

--- a/tgcalls/group/VideoStreamingPart.cpp
+++ b/tgcalls/group/VideoStreamingPart.cpp
@@ -280,6 +280,9 @@ public:
 
         int ret = 0;
 
+#if LIBAVFORMAT_VERSION_MAJOR >= 59
+        const
+#endif
         AVInputFormat *inputFormat = av_find_input_format(container.c_str());
         if (!inputFormat) {
             _didReadToEnd = true;
@@ -323,7 +326,7 @@ public:
         }
 
         if (videoCodecParameters && videoStream) {
-            AVCodec *codec = avcodec_find_decoder(videoCodecParameters->codec_id);
+            const AVCodec *codec = avcodec_find_decoder(videoCodecParameters->codec_id);
             if (codec) {
                 _codecContext = avcodec_alloc_context3(codec);
                 ret = avcodec_parameters_to_context(_codecContext, videoCodecParameters);


### PR DESCRIPTION
It has been released on January 17th. This patch keeps source compatibility with older versions.