### PR TITLE
Fix build with GCC12.

### DIFF
--- a/tgcalls/utils/gzip.h
+++ b/tgcalls/utils/gzip.h
@@ -2,6 +2,7 @@
 #define TGCALLS_UTILS_GZIP_H
 
 #include <absl/types/optional.h>
+#include <cstdint>
 #include <vector>
 
 namespace tgcalls {


### PR DESCRIPTION
This has been in gentoo since 4.0.2 to fix GCC12 build, just sending it in to be upstreamed. 